### PR TITLE
Fix shutdown bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
 
 notifications:
   email:
-on_success: never
+    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,14 @@ matrix:
   include:
     # Minimum rustc version
     - rust: 1.20.0
-      # - rust: nightly
+    - rust: nightly
 
 script:
-  - RUST_TEST_THREADS=1 RUST_LOG="futures_pool=trace" cargo test --test pool natural_shutdown_simple_futures -- --nocapture
-  # - cargo test
-    # - 'if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test --benches; fi'
-  - # - rustdoc --test README.md -L target/debug/deps
-  - # - cargo doc --no-deps
+  - cargo test
+  - 'if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test --benches; fi'
+  - rustdoc --test README.md -L target/debug/deps
+  - cargo doc --no-deps
 
 notifications:
   email:
-    on_success: never
+on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ matrix:
   include:
     # Minimum rustc version
     - rust: 1.20.0
-    - rust: nightly
+      # - rust: nightly
 
 script:
-  - cargo test
-  - 'if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test --benches; fi'
-  - rustdoc --test README.md -L target/debug/deps
-  - cargo doc --no-deps
+  - RUST_TEST_THREADS=1 RUST_LOG="futures_pool=trace" cargo test --test pool natural_shutdown_simple_futures -- --nocapture
+  # - cargo test
+    # - 'if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test --benches; fi'
+  - # - rustdoc --test README.md -L target/debug/deps
+  - # - cargo doc --no-deps
 
 notifications:
   email:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,19 +547,22 @@ impl Inner {
         loop {
             let mut next = state;
 
-            if state.lifecycle() == WORKER_SHUTDOWN {
-                trace!("signal_stop -- WORKER_SHUTDOWN; idx={}", idx);
-                // If the worker is in the shutdown state, then it will never be
-                // started again.
-                self.worker_terminated();
+            match state.lifecycle() {
+                WORKER_SHUTDOWN => {
+                    trace!("signal_stop -- WORKER_SHUTDOWN; idx={}", idx);
+                    // If the worker is in the shutdown state, then it will never be
+                    // started again.
+                    self.worker_terminated();
 
-                return;
-            } else if state.lifecycle() != WORKER_SLEEPING {
-                // TODO: This is probably incorrect
-                trace!("signal_stop -- skipping; idx={}; state={:?}", idx, state);
-                // All other states will naturally converge to a state of
-                // shutdown.
-                return;
+                    return;
+                }
+                WORKER_RUNNING | WORKER_SLEEPING => {}
+                _ => {
+                    trace!("signal_stop -- skipping; idx={}; state={:?}", idx, state);
+                    // All other states will naturally converge to a state of
+                    // shutdown.
+                    return;
+                }
             }
 
             next.set_lifecycle(WORKER_SIGNALED);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,15 +540,15 @@ impl Inner {
     }
 
     /// Signals to the worker that it should stop
-    fn signal_stop(&self, worker: usize, mut state: WorkerState) {
-        let worker = &self.workers[worker];
+    fn signal_stop(&self, idx: usize, mut state: WorkerState) {
+        let worker = &self.workers[idx];
 
         // Transition the worker state to signaled
         loop {
             let mut next = state;
 
             if state.lifecycle() == WORKER_SHUTDOWN {
-                trace!("signal_stop -- WORKER_SHUTDOWN; idx={}", worker);
+                trace!("signal_stop -- WORKER_SHUTDOWN; idx={}", idx);
                 // If the worker is in the shutdown state, then it will never be
                 // started again.
                 self.worker_terminated();
@@ -556,7 +556,7 @@ impl Inner {
                 return;
             } else if state.lifecycle() != WORKER_SLEEPING {
                 // TODO: This is probably incorrect
-                trace!("signal_stop -- skipping; idx={}; state={:?}", worker, state);
+                trace!("signal_stop -- skipping; idx={}; state={:?}", idx, state);
                 // All other states will naturally converge to a state of
                 // shutdown.
                 return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,12 +548,15 @@ impl Inner {
             let mut next = state;
 
             if state.lifecycle() == WORKER_SHUTDOWN {
+                trace!("signal_stop -- WORKER_SHUTDOWN; idx={}", worker);
                 // If the worker is in the shutdown state, then it will never be
                 // started again.
                 self.worker_terminated();
 
                 return;
             } else if state.lifecycle() != WORKER_SLEEPING {
+                // TODO: This is probably incorrect
+                trace!("signal_stop -- skipping; idx={}; state={:?}", worker, state);
                 // All other states will naturally converge to a state of
                 // shutdown.
                 return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1169,7 +1169,7 @@ impl Worker {
     /// Returns `true` if woken up due to new work arriving.
     #[inline]
     fn sleep(&self) -> bool {
-        trace!("Worker::sleep");
+        trace!("Worker::sleep; idx={}", self.idx);
 
         let mut state: WorkerState = self.entry().state.load(Acquire).into();
 
@@ -1271,7 +1271,7 @@ impl Worker {
             state = actual;
         }
 
-        trace!("    -> starting to sleep");
+        trace!("    -> starting to sleep; idx={}", self.idx);
 
         // The state has been transitioned to sleeping, we can now wait on the
         // condvar. This is done in a loop as condvars can wakeup spuriously.

--- a/src/task.rs
+++ b/src/task.rs
@@ -102,6 +102,8 @@ impl Task {
         let actual: State = self.inner().state.compare_and_swap(
             Scheduled.into(), Running.into(), AcqRel).into();
 
+        trace!("running; state={:?}", actual);
+
         match actual {
             Scheduled => {},
             _ => panic!("unexpected task state; {:?}", actual),

--- a/tests/pool.rs
+++ b/tests/pool.rs
@@ -17,7 +17,8 @@ thread_local!(static FOO: Cell<u32> = Cell::new(0));
 fn natural_shutdown_simple_futures() {
     let _ = ::env_logger::init();
 
-    for _ in 0..1_000 {
+    for i in 0..1_000 {
+        println!("~~~~ iter={} ~~~~", i);
         static NUM_INC: AtomicUsize = ATOMIC_USIZE_INIT;
         static NUM_DEC: AtomicUsize = ATOMIC_USIZE_INIT;
 
@@ -62,8 +63,10 @@ fn natural_shutdown_simple_futures() {
             assert_eq!("one", a.recv().unwrap());
             assert_eq!("two", b.recv().unwrap());
 
+            println!("~~~~~~ WAIT ~~~~~~~");
             // Wait for the pool to shutdown
             pool.wait().unwrap();
+            println!("~~~~~~ DONE ~~~~~~~");
 
             // Assert that at least one thread started
             let num_inc = NUM_INC.load(Relaxed);

--- a/tests/pool.rs
+++ b/tests/pool.rs
@@ -18,7 +18,6 @@ fn natural_shutdown_simple_futures() {
     let _ = ::env_logger::init();
 
     for i in 0..1_000 {
-        println!("~~~~ iter={} ~~~~", i);
         static NUM_INC: AtomicUsize = ATOMIC_USIZE_INIT;
         static NUM_DEC: AtomicUsize = ATOMIC_USIZE_INIT;
 
@@ -63,10 +62,8 @@ fn natural_shutdown_simple_futures() {
             assert_eq!("one", a.recv().unwrap());
             assert_eq!("two", b.recv().unwrap());
 
-            println!("~~~~~~ WAIT ~~~~~~~");
             // Wait for the pool to shutdown
             pool.wait().unwrap();
-            println!("~~~~~~ DONE ~~~~~~~");
 
             // Assert that at least one thread started
             let num_inc = NUM_INC.load(Relaxed);

--- a/tests/pool.rs
+++ b/tests/pool.rs
@@ -17,61 +17,63 @@ thread_local!(static FOO: Cell<u32> = Cell::new(0));
 fn natural_shutdown_simple_futures() {
     let _ = ::env_logger::init();
 
-    static NUM_INC: AtomicUsize = ATOMIC_USIZE_INIT;
-    static NUM_DEC: AtomicUsize = ATOMIC_USIZE_INIT;
+    for _ in 0..1_000 {
+        static NUM_INC: AtomicUsize = ATOMIC_USIZE_INIT;
+        static NUM_DEC: AtomicUsize = ATOMIC_USIZE_INIT;
 
-    FOO.with(|f| {
-        f.set(1);
+        FOO.with(|f| {
+            f.set(1);
 
-        let (tx, pool) = Pool::builder()
-            .after_start(|| {
-                NUM_INC.fetch_add(1, Relaxed);
-            })
-            .before_stop(|| {
-                NUM_DEC.fetch_add(1, Relaxed);
-            })
-            .build();
+            let (tx, pool) = Pool::builder()
+                .after_start(|| {
+                    NUM_INC.fetch_add(1, Relaxed);
+                })
+                .before_stop(|| {
+                    NUM_DEC.fetch_add(1, Relaxed);
+                })
+                .build();
 
-        let a = {
-            let (t, rx) = mpsc::channel();
-            tx.execute(lazy(move || {
-                // Makes sure this runs on a worker thread
-                FOO.with(|f| assert_eq!(f.get(), 0));
+            let a = {
+                let (t, rx) = mpsc::channel();
+                tx.execute(lazy(move || {
+                    // Makes sure this runs on a worker thread
+                    FOO.with(|f| assert_eq!(f.get(), 0));
 
-                t.send("one").unwrap();
-                Ok(())
-            })).unwrap();
-            rx
-        };
+                    t.send("one").unwrap();
+                    Ok(())
+                })).unwrap();
+                rx
+            };
 
-        let b = {
-            let (t, rx) = mpsc::channel();
-            tx.execute(lazy(move || {
-                // Makes sure this runs on a worker thread
-                FOO.with(|f| assert_eq!(f.get(), 0));
+            let b = {
+                let (t, rx) = mpsc::channel();
+                tx.execute(lazy(move || {
+                    // Makes sure this runs on a worker thread
+                    FOO.with(|f| assert_eq!(f.get(), 0));
 
-                t.send("two").unwrap();
-                Ok(())
-            })).unwrap();
-            rx
-        };
+                    t.send("two").unwrap();
+                    Ok(())
+                })).unwrap();
+                rx
+            };
 
-        drop(tx);
+            drop(tx);
 
-        assert_eq!("one", a.recv().unwrap());
-        assert_eq!("two", b.recv().unwrap());
+            assert_eq!("one", a.recv().unwrap());
+            assert_eq!("two", b.recv().unwrap());
 
-        // Wait for the pool to shutdown
-        pool.wait().unwrap();
+            // Wait for the pool to shutdown
+            pool.wait().unwrap();
 
-        // Assert that at least one thread started
-        let num_inc = NUM_INC.load(Relaxed);
-        assert!(num_inc > 0);
+            // Assert that at least one thread started
+            let num_inc = NUM_INC.load(Relaxed);
+            assert!(num_inc > 0);
 
-        // Assert that all threads shutdown
-        let num_dec = NUM_DEC.load(Relaxed);
-        assert_eq!(num_inc, num_dec);
-    });
+            // Assert that all threads shutdown
+            let num_dec = NUM_DEC.load(Relaxed);
+            assert_eq!(num_inc, num_dec);
+        });
+    }
 }
 
 #[test]


### PR DESCRIPTION
When shutdown was called while futures were still being processed,
workers that were currently shutdown would not be finalized, which would
block the pool shutdown resolution indefinitely.